### PR TITLE
Handle null argument gracefully

### DIFF
--- a/src/c/mod.rs
+++ b/src/c/mod.rs
@@ -34,6 +34,29 @@ use crate::constants;
 use crate::types::{Account, Provider, Subscription};
 use crate::utils::watch_tx;
 
+fn client_causes_validator(
+    client: *mut ToriiClient,
+    clauses: *const EntityKeysClause,
+    clauses_len: usize,
+) -> Result<bool> {
+    if client.is_null() {
+        return Result::Err(Error {
+            message: CString::new("Invalid client pointer").unwrap().into_raw(),
+        });
+    }
+    if clauses.is_null() {
+        return Result::Err(Error {
+            message: CString::new("Invalid clauses pointer").unwrap().into_raw(),
+        });
+    }
+    if clauses_len == 0 {
+        return Result::Err(Error {
+            message: CString::new("Clauses length cannot be zero").unwrap().into_raw(),
+        });
+    }
+    return Result::Ok(true);
+}
+
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn client_new(
@@ -161,6 +184,12 @@ pub unsafe extern "C" fn client_on_entity_state_update(
     clauses_len: usize,
     callback: unsafe extern "C" fn(types::FieldElement, CArray<Struct>),
 ) -> Result<*mut Subscription> {
+    // Input validation for null pointers and invalid sizes
+    match client_causes_validator(client, clauses, clauses_len) {
+        Result::Ok(_) => {},
+        Result::Err(e) => return Result::Err(e.into()),
+    }
+
     let client = Arc::from_raw(client);
     let clauses = unsafe { std::slice::from_raw_parts(clauses, clauses_len) };
     let clauses = clauses.iter().map(|c| c.into()).collect::<Vec<_>>();
@@ -214,6 +243,12 @@ pub unsafe extern "C" fn client_update_entity_subscription(
     clauses: *const EntityKeysClause,
     clauses_len: usize,
 ) -> Result<bool> {
+    // Input validation for null pointers and invalid sizes
+    match client_causes_validator(client, clauses, clauses_len) {
+        Result::Ok(_) => {},
+        Result::Err(e) => return Result::Err(e.into()),
+    }
+
     let clauses = unsafe { std::slice::from_raw_parts(clauses, clauses_len) };
     let clauses = clauses.iter().map(|c| c.into()).collect::<Vec<_>>();
 
@@ -236,6 +271,12 @@ pub unsafe extern "C" fn client_on_event_message_update(
     historical: bool,
     callback: unsafe extern "C" fn(types::FieldElement, CArray<Struct>),
 ) -> Result<*mut Subscription> {
+    // Input validation for null pointers and invalid sizes
+    match client_causes_validator(client, clauses, clauses_len) {
+        Result::Ok(_) => {},
+        Result::Err(e) => return Result::Err(e.into()),
+    }
+
     let client = Arc::from_raw(client);
     let clauses = unsafe { std::slice::from_raw_parts(clauses, clauses_len) };
     let clauses = clauses.iter().map(|c| c.into()).collect::<Vec<_>>();
@@ -291,6 +332,12 @@ pub unsafe extern "C" fn client_update_event_message_subscription(
     clauses_len: usize,
     historical: bool,
 ) -> Result<bool> {
+    // Input validation for null pointers and invalid sizes
+    match client_causes_validator(client, clauses, clauses_len) {
+        Result::Ok(_) => {},
+        Result::Err(e) => return Result::Err(e.into()),
+    }
+
     let clauses = unsafe { std::slice::from_raw_parts(clauses, clauses_len) };
     let clauses = clauses.iter().map(|c| c.into()).collect::<Vec<_>>();
 
@@ -312,6 +359,12 @@ pub unsafe extern "C" fn client_on_starknet_event(
     clauses_len: usize,
     callback: unsafe extern "C" fn(Event),
 ) -> Result<*mut Subscription> {
+    // Input validation for null pointers and invalid sizes
+    match client_causes_validator(client, clauses, clauses_len) {
+        Result::Ok(_) => {},
+        Result::Err(e) => return Result::Err(e.into()),
+    }
+    
     let client = Arc::from_raw(client);
     let clauses = unsafe { std::slice::from_raw_parts(clauses, clauses_len) };
     let clauses = clauses.iter().map(|c| c.into()).collect::<Vec<_>>();

--- a/src/c/mod.rs
+++ b/src/c/mod.rs
@@ -34,7 +34,7 @@ use crate::constants;
 use crate::types::{Account, Provider, Subscription};
 use crate::utils::watch_tx;
 
-fn client_causes_validator(
+fn client_clauses_validator(
     client: *mut ToriiClient,
     clauses: *const EntityKeysClause,
     clauses_len: usize,
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn client_on_entity_state_update(
     callback: unsafe extern "C" fn(types::FieldElement, CArray<Struct>),
 ) -> Result<*mut Subscription> {
     // Input validation for null pointers and invalid sizes
-    match client_causes_validator(client, clauses, clauses_len) {
+    match client_clauses_validator(client, clauses, clauses_len) {
         Result::Ok(_) => {},
         Result::Err(e) => return Result::Err(e.into()),
     }
@@ -244,7 +244,7 @@ pub unsafe extern "C" fn client_update_entity_subscription(
     clauses_len: usize,
 ) -> Result<bool> {
     // Input validation for null pointers and invalid sizes
-    match client_causes_validator(client, clauses, clauses_len) {
+    match client_clauses_validator(client, clauses, clauses_len) {
         Result::Ok(_) => {},
         Result::Err(e) => return Result::Err(e.into()),
     }
@@ -272,7 +272,7 @@ pub unsafe extern "C" fn client_on_event_message_update(
     callback: unsafe extern "C" fn(types::FieldElement, CArray<Struct>),
 ) -> Result<*mut Subscription> {
     // Input validation for null pointers and invalid sizes
-    match client_causes_validator(client, clauses, clauses_len) {
+    match client_clauses_validator(client, clauses, clauses_len) {
         Result::Ok(_) => {},
         Result::Err(e) => return Result::Err(e.into()),
     }
@@ -333,7 +333,7 @@ pub unsafe extern "C" fn client_update_event_message_subscription(
     historical: bool,
 ) -> Result<bool> {
     // Input validation for null pointers and invalid sizes
-    match client_causes_validator(client, clauses, clauses_len) {
+    match client_clauses_validator(client, clauses, clauses_len) {
         Result::Ok(_) => {},
         Result::Err(e) => return Result::Err(e.into()),
     }
@@ -360,7 +360,7 @@ pub unsafe extern "C" fn client_on_starknet_event(
     callback: unsafe extern "C" fn(Event),
 ) -> Result<*mut Subscription> {
     // Input validation for null pointers and invalid sizes
-    match client_causes_validator(client, clauses, clauses_len) {
+    match client_clauses_validator(client, clauses, clauses_len) {
         Result::Ok(_) => {},
         Result::Err(e) => return Result::Err(e.into()),
     }


### PR DESCRIPTION
In some cases, the dojo.unity SDK sends null as argument to the native functions. 

This seems to be caused by `dojo.EntityKeysClause* clausesPtr = (dojo.EntityKeysClause*)0;` resulting in null and being passed to the native functions.

When this happens Unity will crash without indication. 
Looking at the crash dumps we can see the following:
```
=================================================================
	Native Crash Reporting
=================================================================
Got a UNKNOWN while executing native code. This usually indicates
a fatal error in the mono runtime or one of the native libraries 
used by your application.
=================================================================

=================================================================
	Managed Stacktrace:
=================================================================
=================================================================
Received signal SIGSEGV
Obtained 2 stack frames
RtlLookupFunctionEntry returned NULL function. Aborting stack walk.
<Missing stacktrace information>
```
Or if we are a little bit luckier:
```
=================================================================
	Native Crash Reporting
=================================================================
Got a UNKNOWN while executing native code. This usually indicates
a fatal error in the mono runtime or one of the native libraries 
used by your application.
=================================================================

=================================================================
	Managed Stacktrace:
=================================================================
	  at <unknown> <0xffffffff>
	  at dojo_bindings.dojo:client_on_event_message_update <0x000bb>
	  at Dojo.Torii.ToriiClient:RegisterEventMessageUpdateEvent <0x0032a>
	  at Dojo.Torii.ToriiClient:.ctor <0x0030a>
	  at <Awake>d__4:MoveNext <0x000c2>
	  at System.Runtime.CompilerServices.AsyncVoidMethodBuilder:Start <0x000d2>
	  at Dojo.WorldManager:Awake <0x000c2>
	  at System.Object:runtime_invoke_void__this__ <0x00087>
=================================================================
```


This should also be addressed in the SDK itself, avoiding to call functions with invalid data, but this PR is to help identify this edge case in an easier way and have a more robust error handling. With this changes implemented, we can get an exception directly in the editor without crashing:

![image](https://github.com/user-attachments/assets/6eae7add-c7c3-44f6-83b1-2f35ebf713be)

I might do a PR for dojo.unity in the following days if needed.
